### PR TITLE
add a way for the user to manually trigger a sync - fixes #16

### DIFF
--- a/images/reload.svg
+++ b/images/reload.svg
@@ -1,0 +1,10 @@
+<!--
+    bytesize-icons 1.2
+    https://github.com/danklammer/bytesize-icons
+
+    Copyright 2016 Dan Klammer
+    Released under the MIT license
+-->
+<svg id="i-reload" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+    <path d="M29 16 C29 22 24 29 16 29 8 29 3 22 3 16 3 10 8 3 16 3 21 3 25 6 27 9 M20 10 L27 9 28 2" />
+</svg>

--- a/src/background-script.js
+++ b/src/background-script.js
@@ -1,83 +1,12 @@
 (function(browser) {
-
-adapters = {}
-
-// OWNCLOUD ADAPTER
-// All owncloud specifc stuff goes in here
-
-adapters.owncloud = {
-  pullBookmarks() {
-    return browser.storage.local.get('owncloud')
-    .then(d => {
-      var server = d.owncloud
-      console.log('Fetching bookmarks', server)
-      return fetch(server.url + "/index.php/apps/bookmarks/public/rest/v2/bookmark?page=-1"
-      , {
-        headers: {
-          Authorization: 'basic '+btoa(server.username+':'+server.password)
-        }
-      }
-      )
-    })
-    .then(response => {
-      if (response.status !== 200) return Promise.reject(new Error('Failed to retrieve bookmarks from ownCloud'))
-      else return response.json()
-    })
-    .then((json) => {
-      if ('success' !== json.status) return Promise.reject(json.data)
-      console.log(json)
-      return json.data
-    })
-  }
-, createBookmark(node) {
-    return browser.storage.local.get('owncloud')
-    .then(d => {
-      var server = d.owncloud
-      var body = new FormData()
-      body.append('url', node.url)
-      body.append('title', node.title)
-      return fetch(server.url+'/index.php/apps/bookmarks/public/rest/v2/bookmark', {
-        method: 'POST'
-      , body
-      , headers: {
-          Authorization: 'basic '+btoa(server.username+':'+server.password)
-        }
-      })
-    })
-    .then(res => {
-      console.log(res)
-      if (res.status !== 200) return Promise.reject(new Error('Signing into owncloud for creating a bookmark failed'))
-      return Promise.resolve()
-    })
-    .catch((er) => console.log(er))
-  }
-, removeBookmark(remoteId) {
-    return browser.storage.local.get('owncloud')
-    .then(d => {
-      var server = d.owncloud
-      return fetch(server.url+'/index.php/apps/bookmarks/public/rest/v2/bookmark/'+remoteId, {
-        method: 'DELETE'
-      , headers: {
-          Authorization: 'basic '+btoa(server.username+':'+server.password)
-        }
-      })
-    })
-    .then(res => {
-      console.log(res)
-      if (res.status !== 200) return Promise.reject(new Error('Signing into owncloud for creating a bookmark failed'))
-      return Promise.resolve()
-    })
-    .catch((er) => console.log(er))
-  }
-}
+var bookmarks = client(browser);
 
 // FIRST RUN
 // Set up some things on first run
-
 browser.storage.local.get('notFirstRun')
-.then(d => { 
+.then(d => {
   if (d.notFirstRun) return
-  
+
   // Create Owncloud bookmarks folder and mappings
   bookmarks.init()
 
@@ -89,7 +18,7 @@ browser.storage.local.get('notFirstRun')
     }
   , notFirstRun: true
   })
-  
+
   browser.runtime.openOptionsPage()
 })
 
@@ -100,121 +29,6 @@ browser.alarms.onAlarm.addListener(alarm => {
   .catch(err => console.warn(err))
 })
 
-const bookmarks = {
-  adapter: adapters.owncloud
-, sync() {
-    var mappings 
-      , localRoot
-      , received = {}
-    return Promise.resolve()
-    .then(() => browser.storage.local.get(['bookmarks.localRoot', 'bookmarks.mappings']))
-    .then(d => {
-      mappings = d['bookmarks.mappings']
-      localRoot = d['bookmarks.localRoot']
-    })
-    .then(() => browser.bookmarks.get(localRoot))
-    .then(
-      () => {}
-    , (er) => bookmarks.init()
-    )
-    .then(() => {
-      // In the mappings but not in the tree: SERVERDELETE
-      return Promise.all(
-        Object.keys(mappings.LocalToServer).map(localId => {
-          return browser.bookmarks.get(localId)
-          .then(node => node, er => {
-            console.log('SERVERDELETE', localId, mappings.LocalToServer[localId])
-            return bookmarks.adapter.removeBookmark(mappings.LocalToServer[localId])
-            .then(() => {
-              delete mappings.ServerToLocal[mappings.LocalToServer[localId]]
-              delete mappings.LocalToServer[localId]
-              return Promise.resolve()
-            }, (e) => console.warn(e)) 
-          })
-        })
-      )
-    })
-    .then(() => bookmarks.adapter.pullBookmarks())
-    .then(json => { 
-      // Update known ones and create new ones
-      return Promise.all(
-        json.map(obj => {
-          var localId
-          if (localId = mappings.ServerToLocal[obj.id]) {
-            // known to mappings: UPDATE
-            received[localId] = true
-            console.log('UPDATE', localId, obj)
-            // XXX: Check lastmodified
-            return browser.bookmarks.update(localId, {
-              title: obj.title
-            , url: obj.url
-            })
-          }else{
-            // Not yet known: CREATE
-            return browser.bookmarks.create({parentId: localRoot, title: obj.title, url: obj.url})
-            .then(bookmark => {
-              console.log('CREATE', bookmark.id, obj)
-              received[bookmark.id] = true
-              mappings.ServerToLocal[obj.id] = bookmark.id
-              mappings.LocalToServer[bookmark.id] = obj.id
-            })
-          }
-        })
-      )
-    })
-    .then(() => {
-      // removed on the server: DELETE
-      return Promise.all(
-        Object.keys(mappings.LocalToServer).map(localId => {
-          if (!received[localId]) {
-            // If a bookmark was deleted on the server, we delete it as well
-            console.log('DELETE', localId, mappings.LocalToServer[localId])
-            return browser.bookmarks.remove(localId)
-            .then(() => {
-              delete mappings.ServerToLocal[mappings.LocalToServer[localId]]
-              delete mappings.LocalToServer[localId]
-              return Promise.resolve()
-            })
-          }
-        })
-      )
-    })
-    .then(() => {
-      // In the tree yet not in the mappings: SERVERCREATE
-      return browser.bookmarks.getChildren(localRoot)
-      .then(children => {
-        return Promise.all(
-          children
-          .filter(bookmark => !mappings.LocalToServer[bookmark.id])
-          .map(bookmark => {
-            console.log('SERVERCREATE', bookmark.id, bookmark.url)
-            return bookmarks.adapter.createBookmark(bookmark)
-            .then(()=> {
-              mappings.LocalToServer[bookmark.id] = bookmark.url
-              mappings.ServerToLocal[bookmark.url] = bookmark.id
-              return Promise.resolve()
-            }, (e) => console.warn)
-          })
-        )
-      })
-    })
-    .then(() => {
-      return browser.storage.local.set({'bookmarks.mappings': mappings})
-    })
-  }
-, init() {
-    return browser.bookmarks.getTree()
-    .then(parentNode => browser.bookmarks.create({title: 'Owncloud', parentId: parentNode.id}))
-    .then(bookmark => browser.storage.local.set({'bookmarks.localRoot': bookmark.id}))
-    .then(() => browser.storage.local.set({
-      'bookmarks.mappings': {
-        ServerToLocal: {}
-      , LocalToServer: {}
-      }
-    }))
-    .catch(err => console.warn)
-  }
-}
 
 })((function(){
   if ('undefined' === typeof browser && 'undefined' !== typeof chrome) {

--- a/src/background.html
+++ b/src/background.html
@@ -5,6 +5,7 @@
 </head>
 <body>
 <script src="../lib/chrome-promise.js"></script>
+<script src="./client.js"></script>
 <script src="./background-script.js"></script>
 </body>
 </html>

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,193 @@
+function client(browser) {
+
+adapters = {}
+
+// OWNCLOUD ADAPTER
+// All owncloud specifc stuff goes in here
+
+adapters.owncloud = {
+  pullBookmarks() {
+    return browser.storage.local.get('owncloud')
+    .then(d => {
+      var server = d.owncloud
+      console.log('Fetching bookmarks', server)
+      return fetch(server.url + "/index.php/apps/bookmarks/public/rest/v2/bookmark?page=-1"
+      , {
+        headers: {
+          Authorization: 'basic '+btoa(server.username+':'+server.password)
+        }
+      }
+      )
+    })
+    .then(response => {
+      if (response.status !== 200) return Promise.reject(new Error('Failed to retrieve bookmarks from ownCloud'))
+      else return response.json()
+    })
+    .then((json) => {
+      if ('success' !== json.status) return Promise.reject(json.data)
+      console.log(json)
+      return json.data
+    })
+  }
+, createBookmark(node) {
+    return browser.storage.local.get('owncloud')
+    .then(d => {
+      var server = d.owncloud
+      var body = new FormData()
+      body.append('url', node.url)
+      body.append('title', node.title)
+      return fetch(server.url+'/index.php/apps/bookmarks/public/rest/v2/bookmark', {
+        method: 'POST'
+      , body
+      , headers: {
+          Authorization: 'basic '+btoa(server.username+':'+server.password)
+        }
+      })
+    })
+    .then(res => {
+      console.log(res)
+      if (res.status !== 200) return Promise.reject(new Error('Signing into owncloud for creating a bookmark failed'))
+      return Promise.resolve()
+    })
+    .catch((er) => console.log(er))
+  }
+, removeBookmark(remoteId) {
+    return browser.storage.local.get('owncloud')
+    .then(d => {
+      var server = d.owncloud
+      return fetch(server.url+'/index.php/apps/bookmarks/public/rest/v2/bookmark/'+remoteId, {
+        method: 'DELETE'
+      , headers: {
+          Authorization: 'basic '+btoa(server.username+':'+server.password)
+        }
+      })
+    })
+    .then(res => {
+      console.log(res)
+      if (res.status !== 200) return Promise.reject(new Error('Signing into owncloud for creating a bookmark failed'))
+      return Promise.resolve()
+    })
+    .catch((er) => console.log(er))
+  }
+}
+
+
+const bookmarks = {
+  adapter: adapters.owncloud
+, sync() {
+    var mappings 
+      , localRoot
+      , received = {}
+    return Promise.resolve()
+    .then(() => browser.storage.local.get(['bookmarks.localRoot', 'bookmarks.mappings']))
+    .then(d => {
+      mappings = d['bookmarks.mappings']
+      localRoot = d['bookmarks.localRoot']
+    })
+    .then(() => browser.bookmarks.get(localRoot))
+    .then(
+      () => {}
+    , (er) => bookmarks.init()
+    )
+    .then(() => {
+      // In the mappings but not in the tree: SERVERDELETE
+      return Promise.all(
+        Object.keys(mappings.LocalToServer).map(localId => {
+          return browser.bookmarks.get(localId)
+          .then(node => node, er => {
+            console.log('SERVERDELETE', localId, mappings.LocalToServer[localId])
+            return bookmarks.adapter.removeBookmark(mappings.LocalToServer[localId])
+            .then(() => {
+              delete mappings.ServerToLocal[mappings.LocalToServer[localId]]
+              delete mappings.LocalToServer[localId]
+              return Promise.resolve()
+            }, (e) => console.warn(e)) 
+          })
+        })
+      )
+    })
+    .then(() => bookmarks.adapter.pullBookmarks())
+    .then(json => { 
+      // Update known ones and create new ones
+      return Promise.all(
+        json.map(obj => {
+          var localId
+          if (localId = mappings.ServerToLocal[obj.id]) {
+            // known to mappings: UPDATE
+            received[localId] = true
+            console.log('UPDATE', localId, obj)
+            // XXX: Check lastmodified
+            return browser.bookmarks.update(localId, {
+              title: obj.title
+            , url: obj.url
+            })
+          }else{
+            // Not yet known: CREATE
+            return browser.bookmarks.create({parentId: localRoot, title: obj.title, url: obj.url})
+            .then(bookmark => {
+              console.log('CREATE', bookmark.id, obj)
+              received[bookmark.id] = true
+              mappings.ServerToLocal[obj.id] = bookmark.id
+              mappings.LocalToServer[bookmark.id] = obj.id
+            })
+          }
+        })
+      )
+    })
+    .then(() => {
+      // removed on the server: DELETE
+      return Promise.all(
+        Object.keys(mappings.LocalToServer).map(localId => {
+          if (!received[localId]) {
+            // If a bookmark was deleted on the server, we delete it as well
+            console.log('DELETE', localId, mappings.LocalToServer[localId])
+            return browser.bookmarks.remove(localId)
+            .then(() => {
+              delete mappings.ServerToLocal[mappings.LocalToServer[localId]]
+              delete mappings.LocalToServer[localId]
+              return Promise.resolve()
+            })
+          }
+        })
+      )
+    })
+    .then(() => {
+      // In the tree yet not in the mappings: SERVERCREATE
+      return browser.bookmarks.getChildren(localRoot)
+      .then(children => {
+        return Promise.all(
+          children
+          .filter(bookmark => !mappings.LocalToServer[bookmark.id])
+          .map(bookmark => {
+            console.log('SERVERCREATE', bookmark.id, bookmark.url)
+            return bookmarks.adapter.createBookmark(bookmark)
+            .then(()=> {
+              mappings.LocalToServer[bookmark.id] = bookmark.url
+              mappings.ServerToLocal[bookmark.url] = bookmark.id
+              return Promise.resolve()
+            }, (e) => console.warn)
+          })
+        )
+      })
+    })
+    .then(() => {
+      return browser.storage.local.set({'bookmarks.mappings': mappings})
+    })
+  }
+, init() {
+    return browser.bookmarks.getTree()
+    .then(parentNode => browser.bookmarks.create({title: 'Owncloud', parentId: parentNode.id}))
+    .then(bookmark => browser.storage.local.set({'bookmarks.localRoot': bookmark.id}))
+    .then(() => browser.storage.local.set({
+      'bookmarks.mappings': {
+        ServerToLocal: {}
+      , LocalToServer: {}
+      }
+    }))
+    .catch(err => console.warn)
+  }
+}
+
+return bookmarks;
+
+}

--- a/src/options.html
+++ b/src/options.html
@@ -4,11 +4,16 @@
   <title>Floccus options</title>
 </head>
 <body>
+<p><button type="button" id="sync">
+  <img src="../images/reload.svg" width="15" height="15">
+</button></p>
+<hr>
 <p><label>Owncloud server URL: <input type="text" id="url"/></label></p>
 <p><label>Owncloud user name: <input type="text" id="username"/></label></p>
 <p><label>Owncloud password: <input type="password" id="password"/></label></p>
 <p><button type="submit" id="submit">Save</button></p>
 <script src="../lib/chrome-promise.js"></script>
+<script src="./client.js"></script>
 <script src="./options.js"></script>
 </body>
 </html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,9 @@
 (function(browser) {
+  var bookmarks = client(browser);
+
+  document.getElementById('sync').addEventListener('click', () => {
+    bookmarks.sync();
+  });
 
 browser.storage.local.get('owncloud')
 .then(d => {


### PR DESCRIPTION
This PR moves the adapter and http requests into its own client file, which is used in the background script and in the options to trigger a manual sync.
ALso this adds a reload icon from the bytesize library for the reload/sync button.

This is for #16 